### PR TITLE
switch from object to Mappable, add tests

### DIFF
--- a/src/objects/Arrayable.ts
+++ b/src/objects/Arrayable.ts
@@ -151,7 +151,7 @@ class Arrayable<T> extends Array<T> {
         return this.reduce<Mappable<K, Arrayable<T>>>((result, item) => {
             const group = typeof key === "function" ? key(item) : item[key]
             if (result.has(group)) {
-                const newItem = new this.constructor(...result.get(group), item)
+                result.get(group).push(item)
                 result.set(group, newItem)
             } else {
                 result.set(group, this.constructor.from([item]))

--- a/src/objects/Arrayable.ts
+++ b/src/objects/Arrayable.ts
@@ -147,15 +147,17 @@ class Arrayable<T> extends Array<T> {
         return this.constructor.from(clonedeep([...this])) as Arrayable<T>
     }
 
-    groupBy(key: string | Function) {
-        const grouped = this.reduce<{ [key: string]: Arrayable<T> }>((result, item) => {
+    groupBy<K>(key: string | Function) {
+        return this.reduce<Mappable<K, Arrayable<T>>>((result, item) => {
             const group = typeof key === "function" ? key(item) : item[key]
-            result[group] = result[group] || new this.constructor()
-            result[group].push(item)
+            if (result.has(group)) {
+                const newItem = new this.constructor(...result.get(group), item)
+                result.set(group, newItem)
+            } else {
+                result.set(group, new this.constructor(item))
+            }
             return result
-        }, {})
-
-        return new Mappable(grouped)
+        }, new Mappable<K, Arrayable<T>>())
     }
 
     sum(key?: string | ((item: T) => number)) {

--- a/src/objects/Arrayable.ts
+++ b/src/objects/Arrayable.ts
@@ -152,7 +152,6 @@ class Arrayable<T> extends Array<T> {
             const group = typeof key === "function" ? key(item) : item[key]
             if (result.has(group)) {
                 result.get(group).push(item)
-                result.set(group, newItem)
             } else {
                 result.set(group, this.constructor.from([item]))
             }

--- a/src/objects/Arrayable.ts
+++ b/src/objects/Arrayable.ts
@@ -147,8 +147,8 @@ class Arrayable<T> extends Array<T> {
         return this.constructor.from(clonedeep([...this])) as Arrayable<T>
     }
 
-    groupBy<K>(key: string | Function) {
-        return this.reduce<Mappable<K, Arrayable<T>>>((result, item) => {
+    groupBy<K extends keyof T>(key: K | ((item: T) => T[K]) ) {
+        return this.reduce<Mappable<T[K], Arrayable<T>>>((result, item) => {
             const group = typeof key === "function" ? key(item) : item[key]
             if (result.has(group)) {
                 result.get(group).push(item)
@@ -156,7 +156,7 @@ class Arrayable<T> extends Array<T> {
                 result.set(group, this.constructor.from([item]))
             }
             return result
-        }, new Mappable<K, Arrayable<T>>())
+        }, new Mappable<T[K], Arrayable<T>>())
     }
 
     sum(key?: string | ((item: T) => number)) {

--- a/src/objects/Arrayable.ts
+++ b/src/objects/Arrayable.ts
@@ -154,7 +154,7 @@ class Arrayable<T> extends Array<T> {
                 const newItem = new this.constructor(...result.get(group), item)
                 result.set(group, newItem)
             } else {
-                result.set(group, new this.constructor(item))
+                result.set(group, this.constructor.from([item]))
             }
             return result
         }, new Mappable<K, Arrayable<T>>())

--- a/test/arrayable.spec.js
+++ b/test/arrayable.spec.js
@@ -186,6 +186,26 @@ test('groupBy() groups an array of objects by the given key', assert => {
   })
 })
 
+test('groupBy() maintains key type (string)', assert => {
+  const users = [{ id: 1, area: 'New York' }, { id: 2, area: 'New York'}, { id: 3, area: 'LA' }]
+  const groupByType = 'string'
+  const result = given(users).groupBy('area')
+
+  Array.from(result.keys()).map(k => {
+    assert.equal(typeof k, groupByType)
+  })
+})
+
+test('groupBy() maintains key type (number)', assert => {
+  const users = [{ id: 1, area: 'New York' }, { id: 2, area: 'New York'}, { id: 3, area: 'LA' }]
+  const groupByType = 'number'
+  const result = given(users).groupBy('id')
+
+  Array.from(result.keys()).map(k => {
+    assert.equal(typeof k, groupByType)
+  })
+})
+
 test('groupBy() groups an array of object by the given key transformation', assert => {
   const users = [{ id: 1, area: 'New York' }, { id: 2, area: 'New York'}, { id: 3, area: 'LA' }]
   const result = given(users).groupBy(item => item.area.toLowerCase()).toJSON()

--- a/test/arrayable.spec.js
+++ b/test/arrayable.spec.js
@@ -191,7 +191,7 @@ test('groupBy() maintains key type (string)', assert => {
   const groupByType = 'string'
   const result = given(users).groupBy('area')
 
-  Array.from(result.keys()).map(k => {
+  result.keys().map(k => {
     assert.equal(typeof k, groupByType)
   })
 })
@@ -201,7 +201,7 @@ test('groupBy() maintains key type (number)', assert => {
   const groupByType = 'number'
   const result = given(users).groupBy('id')
 
-  Array.from(result.keys()).map(k => {
+  result.keys().map(k => {
     assert.equal(typeof k, groupByType)
   })
 })


### PR DESCRIPTION
this is to maintain the type signature when using groupBy. before this, the regardless of the key type (number, string, boolean etc), when you call groupBy it gets coerced into a string because an object was used to create the groupBy object. switching to Mappable (extension of Map()) preserves this type signature, bringing it closer to what we expect of a javascript Map() object.